### PR TITLE
[#4 FEAT] 인증 기능 구현 (회원가입, 로그인, 로그아웃, 회원탈퇴)

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
+    <data-source source="LOCAL" name="parker@localhost" uuid="512cacea-e71f-4288-a3b4-a3a265b7f2c1">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>jdbc:mysql://localhost:3306/parker</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -3,6 +3,7 @@
   <component name="ProjectModuleManager">
     <modules>
       <module fileurl="file://$PROJECT_DIR$/.idea/Parker_Backend.iml" filepath="$PROJECT_DIR$/.idea/Parker_Backend.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/parker.main.iml" filepath="$PROJECT_DIR$/.idea/modules/parker.main.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules/parker.main.iml
+++ b/.idea/modules/parker.main.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="AdditionalModuleElements">
+    <content url="file://$MODULE_DIR$/../../parker/build/generated/sources/annotationProcessor/java/main">
+      <sourceFolder url="file://$MODULE_DIR$/../../parker/build/generated/sources/annotationProcessor/java/main" isTestSource="false" generated="true" />
+    </content>
+  </component>
+</module>

--- a/parker/build.gradle
+++ b/parker/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/parker/build.gradle
+++ b/parker/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/parker/src/main/java/com/si9nal/parker/ParkerApplication.java
+++ b/parker/src/main/java/com/si9nal/parker/ParkerApplication.java
@@ -2,8 +2,10 @@ package com.si9nal.parker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ParkerApplication {
 
 	public static void main(String[] args) {

--- a/parker/src/main/java/com/si9nal/parker/bookmark/domain/SpaceBookmark.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/domain/SpaceBookmark.java
@@ -2,7 +2,7 @@ package com.si9nal.parker.bookmark.domain;
 
 import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.parkingspace.domain.ParkingSpace;
-import com.si9nal.parker.user.User;
+import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/parker/src/main/java/com/si9nal/parker/bookmark/domain/ViolationBookmark.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/domain/ViolationBookmark.java
@@ -2,7 +2,7 @@ package com.si9nal.parker.bookmark.domain;
 
 import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.parkingvioation.domain.ParkingViolation;
-import com.si9nal.parker.user.User;
+import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
@@ -23,7 +23,7 @@ public class WebSecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/user/signup").permitAll()
+                        .requestMatchers("/api/user/signup", "/api/user/login").permitAll()
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
@@ -1,0 +1,36 @@
+package com.si9nal.parker.global.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        return http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/user/signup").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
@@ -1,5 +1,7 @@
 package com.si9nal.parker.global.common.config;
 
+import com.si9nal.parker.global.common.security.JwtFilter;
+import com.si9nal.parker.global.common.security.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,10 +11,13 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @RequiredArgsConstructor
 @Configuration
 public class WebSecurityConfig {
+
+    private final TokenProvider tokenprovider;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -26,7 +31,13 @@ public class WebSecurityConfig {
                         .requestMatchers("/api/user/signup", "/api/user/login").permitAll()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(new JwtFilter(tokenprovider), UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public JwtFilter jwtFilter() {
+        return new JwtFilter(tokenprovider);
     }
 
     @Bean

--- a/parker/src/main/java/com/si9nal/parker/global/common/security/JwtFilter.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/security/JwtFilter.java
@@ -1,0 +1,31 @@
+package com.si9nal.parker.global.common.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    private final TokenProvider tokenProvider;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+        String token = tokenProvider.resolveToken((HttpServletRequest) request);
+
+        if (StringUtils.hasText(token) && tokenProvider.validateToken(token)) {
+            Authentication authentication = tokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/security/TokenProvider.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/security/TokenProvider.java
@@ -1,0 +1,35 @@
+package com.si9nal.parker.global.common.security;
+
+import com.si9nal.parker.user.domain.User;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class TokenProvider {
+
+    private final Key key;
+    private final long accessTokenValidityTime;
+
+    public TokenProvider(@Value("${jwt.secret}") String secretKey,
+                         @Value("${jwt.access-token-validity-in-milliseconds}") long accessTokenValidityTime) {
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenValidityTime = accessTokenValidityTime;
+    }
+
+    public String createAccessToken(User user) {
+        long nowTime = (new Date().getTime());
+        Date accessTokenExpiredTime = new Date(nowTime + accessTokenValidityTime);
+
+        return Jwts.builder()
+                .setSubject(user.getId().toString())
+                .setExpiration(accessTokenExpiredTime)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/security/TokenProvider.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/security/TokenProvider.java
@@ -4,16 +4,30 @@ import com.si9nal.parker.user.domain.User;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
 import java.security.Key;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class TokenProvider {
 
     private final Key key;
     private final long accessTokenValidityTime;
+    private static final String BEARER = "Bearer ";
+    private static final String AUTHORIZATION = "Authorization";
+    private static final String ROLE_CLAIM = "Role";
 
     public TokenProvider(@Value("${jwt.secret}") String secretKey,
                          @Value("${jwt.access-token-validity-in-milliseconds}") long accessTokenValidityTime) {
@@ -28,8 +42,78 @@ public class TokenProvider {
 
         return Jwts.builder()
                 .setSubject(user.getId().toString())
+                .claim("email", user.getEmail())
                 .setExpiration(accessTokenExpiredTime)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
+            return bearerToken.substring(7);
+        }
+
+        return null;
+    }
+
+    public long getTokenExpiration(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getExpiration().getTime() - System.currentTimeMillis();
+        } catch (JwtException e) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.", e);
+        }
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token);
+            return true;
+        } catch (UnsupportedJwtException | ExpiredJwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Authentication getAuthentication(String accessToken) {
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get("email") == null) {
+            throw new RuntimeException("이메일 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                claims.get("email"),
+                "",
+                authorities
+        );
+
+        authentication.setDetails(claims);
+
+        return authentication;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(accessToken)
+                    .getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        } catch (io.jsonwebtoken.security.SignatureException e) {
+            throw new RuntimeException("토큰 복호화에 실패했습니다.");
+        }
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/report/domain/Report.java
+++ b/parker/src/main/java/com/si9nal/parker/report/domain/Report.java
@@ -2,7 +2,7 @@ package com.si9nal.parker.report.domain;
 
 import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.report.domain.enums.ApprovalStatus;
-import com.si9nal.parker.user.User;
+import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
+++ b/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
@@ -1,9 +1,12 @@
 package com.si9nal.parker.user.controller;
 
+import com.si9nal.parker.user.dto.req.UserLoginReqDto;
 import com.si9nal.parker.user.dto.req.UserSignupReqDto;
+import com.si9nal.parker.user.dto.res.TokenDto;
 import com.si9nal.parker.user.dto.res.UserInfoResDto;
 import com.si9nal.parker.user.service.UserService;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,5 +27,13 @@ public class UserController {
     public ResponseEntity<UserInfoResDto> SignUp(@RequestBody UserSignupReqDto request) {
         UserInfoResDto savedUser = userService.SingUp(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenDto> Login(@RequestBody UserLoginReqDto request) {
+        TokenDto tokenDto = userService.Login(request);
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(tokenDto);
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
+++ b/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.si9nal.parker.user.dto.req.UserSignupReqDto;
 import com.si9nal.parker.user.dto.res.TokenDto;
 import com.si9nal.parker.user.dto.res.UserInfoResDto;
 import com.si9nal.parker.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import java.security.Principal;
 
 @RestController
 @RequestMapping("/api/user")
@@ -35,5 +37,11 @@ public class UserController {
         return ResponseEntity.ok()
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(tokenDto);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(Principal principal, HttpServletRequest request) {
+        userService.logout(principal, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
+++ b/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.si9nal.parker.user.controller;
+
+import com.si9nal.parker.user.dto.req.UserSignupReqDto;
+import com.si9nal.parker.user.dto.res.UserInfoResDto;
+import com.si9nal.parker.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<UserInfoResDto> SignUp(@RequestBody UserSignupReqDto request) {
+        UserInfoResDto savedUser = userService.SingUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(savedUser);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
+++ b/parker/src/main/java/com/si9nal/parker/user/controller/UserController.java
@@ -44,4 +44,10 @@ public class UserController {
         userService.logout(principal, request);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/deleteUser")
+    public ResponseEntity<Void> deleteUser(Principal principal, HttpServletRequest request) {
+        userService.deleteUser(principal, request);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/parker/src/main/java/com/si9nal/parker/user/domain/User.java
+++ b/parker/src/main/java/com/si9nal/parker/user/domain/User.java
@@ -1,17 +1,16 @@
-package com.si9nal.parker.user;
+package com.si9nal.parker.user.domain;
 
 import com.si9nal.parker.global.common.BaseEntity;
-import com.si9nal.parker.user.enums.Status;
+import com.si9nal.parker.user.domain.enums.Status;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     @Id

--- a/parker/src/main/java/com/si9nal/parker/user/domain/enums/Status.java
+++ b/parker/src/main/java/com/si9nal/parker/user/domain/enums/Status.java
@@ -1,0 +1,5 @@
+package com.si9nal.parker.user.domain.enums;
+
+public enum Status {
+    ACTIVE, INACTIVE
+}

--- a/parker/src/main/java/com/si9nal/parker/user/dto/req/UserLoginReqDto.java
+++ b/parker/src/main/java/com/si9nal/parker/user/dto/req/UserLoginReqDto.java
@@ -1,0 +1,9 @@
+package com.si9nal.parker.user.dto.req;
+
+import lombok.Getter;
+
+@Getter
+public class UserLoginReqDto {
+    private String email;
+    private String password;
+}

--- a/parker/src/main/java/com/si9nal/parker/user/dto/req/UserSignupReqDto.java
+++ b/parker/src/main/java/com/si9nal/parker/user/dto/req/UserSignupReqDto.java
@@ -1,0 +1,24 @@
+package com.si9nal.parker.user.dto.req;
+
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.domain.enums.Status;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class UserSignupReqDto {
+    private String email;
+    private String phoneNumber;
+    private String password;
+    private String name;
+
+    public User toEntity() {
+        return User.builder()
+                .email(this.email)
+                .phoneNumber(this.phoneNumber)
+                .name(this.name)
+                .status(Status.ACTIVE)
+                .build();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/dto/res/TokenDto.java
+++ b/parker/src/main/java/com/si9nal/parker/user/dto/res/TokenDto.java
@@ -1,0 +1,16 @@
+package com.si9nal.parker.user.dto.res;
+
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+public class TokenDto {
+    private String accessToken;
+
+    @Builder
+    public TokenDto(String accessToken) {
+        this.accessToken = accessToken;
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/dto/res/UserInfoResDto.java
+++ b/parker/src/main/java/com/si9nal/parker/user/dto/res/UserInfoResDto.java
@@ -1,0 +1,30 @@
+package com.si9nal.parker.user.dto.res;
+
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.domain.enums.Status;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserInfoResDto {
+    private Long id;
+    private String email;
+    private String nickname;
+    private String phoneNumber;
+    private String name;
+    private Status status;
+
+    public static UserInfoResDto fromEntity(User user) {
+        return UserInfoResDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .phoneNumber(user.getPhoneNumber())
+                .name(user.getName())
+                .status(user.getStatus())
+                .build();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/enums/Status.java
+++ b/parker/src/main/java/com/si9nal/parker/user/enums/Status.java
@@ -1,5 +1,0 @@
-package com.si9nal.parker.user.enums;
-
-public enum Status {
-    ACTIVE, INACTIVE
-}

--- a/parker/src/main/java/com/si9nal/parker/user/repository/UserRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.si9nal.parker.user.repository;
+
+import com.si9nal.parker.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
+++ b/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
@@ -75,4 +75,21 @@ public class UserService {
         long expirationTime = tokenProvider.getTokenExpiration(token);
         redisTemplate.opsForValue().set(token, "blacklisted", Duration.ofMillis(expirationTime));
     }
+
+    @Transactional
+    public void deleteUser(Principal principal, HttpServletRequest request) {
+        if (principal == null) {
+            throw new IllegalStateException("인증된 사용자가 존재하지 않습니다.");
+        }
+
+        String email = principal.getName();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자가 존재하지 않습니다."));
+
+        String token = tokenProvider.resolveToken(request);
+        redisTemplate.delete(token);
+
+        userRepository.delete(user);
+    }
 }

--- a/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
+++ b/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
@@ -1,0 +1,33 @@
+package com.si9nal.parker.user.service;
+
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.dto.req.UserSignupReqDto;
+import com.si9nal.parker.user.dto.res.UserInfoResDto;
+import com.si9nal.parker.user.repository.UserRepository;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    public UserInfoResDto SingUp(UserSignupReqDto request) {
+
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+        }
+
+        User user = request.toEntity();
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        userRepository.save(user);
+
+        return UserInfoResDto.fromEntity(user);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
+++ b/parker/src/main/java/com/si9nal/parker/user/service/UserService.java
@@ -1,21 +1,27 @@
 package com.si9nal.parker.user.service;
 
+import com.si9nal.parker.global.common.security.TokenProvider;
 import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.dto.req.UserLoginReqDto;
 import com.si9nal.parker.user.dto.req.UserSignupReqDto;
+import com.si9nal.parker.user.dto.res.TokenDto;
 import com.si9nal.parker.user.dto.res.UserInfoResDto;
 import com.si9nal.parker.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final TokenProvider tokenProvider;
 
-    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+    public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder, TokenProvider tokenProvider) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.tokenProvider = tokenProvider;
     }
 
     public UserInfoResDto SingUp(UserSignupReqDto request) {
@@ -29,5 +35,22 @@ public class UserService {
         userRepository.save(user);
 
         return UserInfoResDto.fromEntity(user);
+    }
+
+    @Transactional
+    public TokenDto Login(UserLoginReqDto request){
+
+        User user = userRepository.findByEmail(request.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 틀립니다.");
+        }
+
+        String accessToken = tokenProvider.createAccessToken(user);
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .build();
     }
 }

--- a/parker/src/main/resources/application.properties
+++ b/parker/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=parker

--- a/parker/src/main/resources/application.yml
+++ b/parker/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  application:
+    name: parker
+
+  datasource:
+    url: ${DB_JDBC_URL}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: false
+        use_sql_comments: true
+
+server:
+  port: 8080

--- a/parker/src/main/resources/application.yml
+++ b/parker/src/main/resources/application.yml
@@ -19,5 +19,9 @@ spring:
         format_sql: false
         use_sql_comments: true
 
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity-in-milliseconds: ${ACCESS_TOKEN_VALIDITY_IN_MILLISECONDS}
+
 server:
   port: 8080


### PR DESCRIPTION
# ✨ 구현한 내용

인증 관련 주요 기능을 구현했습니다. 
Spring Security + JWT + Redis를 활용하여 인증/인가를 처리합니다.

### 1. 회원가입 기능
- /api/user/signup 엔드포인트 추가
- 사용자가 이메일, 비밀번호, 이름, 전화번호를 입력하여 가입 가능
- 비밀번호는 BCryptPasswordEncoder로 암호화하여 저장
- 중복 이메일 예외 처리 구현
- 회원가입 후 UserInfoResDto 반환

📎 샘플 데이터
<img width="340" alt="스크린샷 2025-01-25 오후 11 40 38" src="https://github.com/user-attachments/assets/0e1ec77c-af85-4ab0-aacf-30059828fe6e" />


### 2. 로그인 기능
- /api/user/login 엔드포인트 추가
- 이메일과 비밀번호로 로그인 처리
- 로그인 성공 시 JWT 발급 및 응답
- 유효하지 않은 이메일/비밀번호 예외 처리 구현
- 로그인 후 TokenDto 반환

### 3. 로그아웃 기능
- /api/user/logout 엔드포인트 추가
- 인증된 사용자의 토큰을 Redis에 블랙리스트로 등록
- 등록된 블랙리스트 토큰은 이후 유효하지 않게 처리

### 4. 회원탈퇴 기능
- /api/user/deleteUser 엔드포인트 추가
- Principal 객체를 통해 인증된 사용자를 식별
- Redis에서 토큰 삭제 및 사용자 데이터 삭제
- 인증되지 않은 사용자에 대한 예외 처리 구현
<br><br>


# ✅ 테스트 내용
- 회원가입, 로그인, 로그아웃, 회원탈퇴 기능 각각에 대한 테스트 완료
- JWT 발급 및 Redis 블랙리스트 등록 확인
- 회원탈퇴 시 Redis에서 토큰삭제 및 DB 상 회원 삭제 확인
- 인증된 사용자만이 로그아웃/회원탈퇴를 수행할 수 있는지 확인

📎 테스트 결과 스크린샷
<img width="1322" alt="스크린샷 2025-01-25 오후 11 39 20" src="https://github.com/user-attachments/assets/be5b1246-7ba7-4b12-8676-366aa7c7b501" />
<br><br>


# 📌 중점 리뷰 사항
- 회원가입 시 닉네임을 받지 않아 NULL 처리를 했는데 다른 방식이 있을지
- 회원가입 후 바로 Status를 ACTIVE로 변경했는데 이 로직이 적합한지
<br><br>


# 🪪 이슈번호 : #4 
<br><br>


# 🙋‍♂️ 리뷰어
@bigtr3  @jiwonniy @yina00 
