### PR TITLE
[#14 Feat] 불법 주정차 단속 위치 정보 상세 조회 기능 개선

### DIFF
--- a/parker/src/main/java/com/si9nal/parker/parkingvioation/controller/ParkingViolationDetailController.java
+++ b/parker/src/main/java/com/si9nal/parker/parkingvioation/controller/ParkingViolationDetailController.java
@@ -1,0 +1,46 @@
+package com.si9nal.parker.parkingvioation.controller;
+
+import com.si9nal.parker.parkingvioation.dto.res.ParkingViolationDetailResponseDto;
+import com.si9nal.parker.parkingvioation.service.ParkingViolationDetailService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/parking-violation")
+public class ParkingViolationDetailController {
+
+    private final ParkingViolationDetailService parkingViolationDetailService;
+
+    public ParkingViolationDetailController(ParkingViolationDetailService parkingViolationDetailService) {
+        this.parkingViolationDetailService = parkingViolationDetailService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ParkingViolationDetailResponseDto>> getAllParkingViolations() {
+        List<ParkingViolationDetailResponseDto> allParkingViolations = parkingViolationDetailService.getAllParkingViolationDetails();
+
+        if (allParkingViolations.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+
+        return ResponseEntity.ok(allParkingViolations);
+    }
+
+
+    @GetMapping("/detailedLocation/{detailedLocation}")
+    public ResponseEntity<ParkingViolationDetailResponseDto> getParkingViolationDetail(@PathVariable String detailedLocation) {
+        ParkingViolationDetailResponseDto response = parkingViolationDetailService.getParkingViolationDetailByDetailedLocation(detailedLocation);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/id/{id}")
+    public ResponseEntity<ParkingViolationDetailResponseDto> getParkingViolationDetailById(@PathVariable Long id) {
+        ParkingViolationDetailResponseDto response = parkingViolationDetailService.getParkingViolationDetailById(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/parkingvioation/domain/ParkingViolation.java
+++ b/parker/src/main/java/com/si9nal/parker/parkingvioation/domain/ParkingViolation.java
@@ -28,6 +28,8 @@ public class ParkingViolation extends BaseEntity {
     private String sigunguName;
 
     private String roadName;
+
+    @Column(length = 500)
     private String detailedLocation;
 
     @Column(length = 15)

--- a/parker/src/main/java/com/si9nal/parker/parkingvioation/dto/res/ParkingViolationDetailResponseDto.java
+++ b/parker/src/main/java/com/si9nal/parker/parkingvioation/dto/res/ParkingViolationDetailResponseDto.java
@@ -1,0 +1,43 @@
+package com.si9nal.parker.parkingvioation.dto.res;
+
+import com.si9nal.parker.parkingvioation.domain.ParkingViolation;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ParkingViolationDetailResponseDto {
+    private Long id;
+    private String sidoName;
+    private String sigunguName;
+    private String roadName;
+    private String detailedLocation;
+    private String managementPhoneNumber;
+    private String weekdayTime;
+    private String saturdayTime;
+    private String holidayTime;
+
+    public static ParkingViolationDetailResponseDto fromEntity(ParkingViolation violation) {
+        return ParkingViolationDetailResponseDto.builder()
+                .id(violation.getId())
+                .sidoName(violation.getSidoName())
+                .sigunguName(violation.getSigunguName())
+                .roadName(violation.getRoadName())
+                .detailedLocation(violation.getDetailedLocation())
+                .managementPhoneNumber(violation.getManagementPhoneNumber())
+                .weekdayTime(formatTimeRange(violation.getWeekdayStartTime(), violation.getWeekdayEndTime()))
+                .saturdayTime(formatTimeRange(violation.getSaturdayStartTime(), violation.getSaturdayEndTime()))
+                .holidayTime(formatTimeRange(violation.getHolidayStartTime(), violation.getHolidayEndTime()))
+                .build();
+    }
+
+    private static String formatTimeRange(LocalTime startTime, LocalTime endTime) {
+        if (startTime == null || endTime == null) {
+            return "단속 없음";
+        }
+        return startTime.toString() + " ~ " + endTime.toString();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/parkingvioation/repository/ParkingViolationRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/parkingvioation/repository/ParkingViolationRepository.java
@@ -1,0 +1,10 @@
+package com.si9nal.parker.parkingvioation.repository;
+
+import com.si9nal.parker.parkingvioation.domain.ParkingViolation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ParkingViolationRepository extends JpaRepository<ParkingViolation, Long> {
+    Optional<ParkingViolation> findByDetailedLocation(String detailedLocation);
+}

--- a/parker/src/main/java/com/si9nal/parker/parkingvioation/service/ParkingViolationDetailService.java
+++ b/parker/src/main/java/com/si9nal/parker/parkingvioation/service/ParkingViolationDetailService.java
@@ -1,0 +1,40 @@
+package com.si9nal.parker.parkingvioation.service;
+
+import com.si9nal.parker.parkingvioation.domain.ParkingViolation;
+import com.si9nal.parker.parkingvioation.dto.res.ParkingViolationDetailResponseDto;
+import com.si9nal.parker.parkingvioation.repository.ParkingViolationRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ParkingViolationDetailService {
+
+    private final ParkingViolationRepository parkingViolationRepository;
+
+    public ParkingViolationDetailService(ParkingViolationRepository parkingViolationRepository) {
+        this.parkingViolationRepository = parkingViolationRepository;
+    }
+
+    public List<ParkingViolationDetailResponseDto> getAllParkingViolationDetails() {
+        List<ParkingViolation> parkingViolations = parkingViolationRepository.findAll();
+
+        return parkingViolations.stream()
+                .map(ParkingViolationDetailResponseDto::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public ParkingViolationDetailResponseDto getParkingViolationDetailByDetailedLocation(String detailedLocation) {
+        ParkingViolation violation = parkingViolationRepository.findByDetailedLocation(detailedLocation)
+                .orElseThrow(() -> new IllegalArgumentException("해당 위치의 불법 주정차 정보가 없습니다."));
+
+        return ParkingViolationDetailResponseDto.fromEntity(violation);
+    }
+
+    public ParkingViolationDetailResponseDto getParkingViolationDetailById(Long id) {
+        ParkingViolation violation = parkingViolationRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 위치의 불법 주정차 정보가 없습니ㅏㄷ."));
+
+        return ParkingViolationDetailResponseDto.fromEntity(violation);
+    }
+}


### PR DESCRIPTION
# ✨ 구현한 내용
- CSV 데이터를 MySQL DB에 저장하여 조회하는 방식으로 변경
- ParkingViolation 엔티티 중 detailedLocation 필드의 길이 제한을 500으로 설정
- ParkingViolationResponseDto에 ID 필드 추가
- 상세 조회 시 ID 기반과 상세 위치(detailedLocation) 기반 조회 기능 모두 구현
- URL 경로 충돌 방지를 위해 ID 조회(/api/parking-violation/id/{id}), 위치 조회(/api/parking-violation/location/{detailedLocation})로 명확히 분리
<br>

### [ 불법 주정차 단속 위치 정보 조회 기능 ]
**CSV 데이터를 MySQL DB에 저장**하여 불법 주정차 단속 위치 정보 상세 조회 
<br><br>

📎 샘플 데이터 
- 아래 명령어를 통해 csv 파일의 데이터를 mysql 서버에 저장
<img width="768" alt="스크린샷 2025-02-03 오전 1 06 58" src="https://github.com/user-attachments/assets/5d84efd3-7551-4411-b5d5-2ca616765f7c" />

<br><br>


# ✅ 테스트 내용
- 전체 조회 불법주정차상세조회
<img width="382" alt="스크린샷 2025-02-03 오전 1 09 04" src="https://github.com/user-attachments/assets/24bf448b-27cd-499c-ab75-7a21d8669c83" />

- 불법주정차 ID별 불법주정차상세조회
<img width="334" alt="스크린샷 2025-02-03 오전 1 10 13" src="https://github.com/user-attachments/assets/0918269f-6a24-4fcc-911c-25ed64eb4a71" />

<br><br>


# 📌 중점 리뷰 사항
- CSV 데이터를 MySQL에 직접 주입하는 방식을 적절히 사용했는지 확인 부탁드립니다!

# 🪪 이슈번호 : [#14 ]
<br><br>


# 🙋‍♂️ 리뷰어
@bigtr3 @jiwonniy @yina00 
