### PR TITLE
[#13 Feat] Swagger 설정

### DIFF
--- a/parker/build.gradle
+++ b/parker/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+	//Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/SwaggerConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.si9nal.parker.global.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        Info info = new Info()
+                .title("Parker API")
+                .description("불법 주정차 구역 관리 서비스 Parker API 명세서")
+                .version("1.0.0");
+
+        String jwtSchemeName = "JWT TOKEN";
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
@@ -28,7 +28,8 @@ public class WebSecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/user/signup", "/api/user/login").permitAll()
+                        .requestMatchers("/api/user/signup", "/api/user/login", "/v3/api-docs/**",
+                                "/swagger-ui/**").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(new JwtFilter(tokenprovider), UsernamePasswordAuthenticationFilter.class)

--- a/parker/src/main/resources/application.yml
+++ b/parker/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:
@@ -22,6 +22,15 @@ spring:
 jwt:
   secret: ${JWT_SECRET}
   access-token-validity-in-milliseconds: ${ACCESS_TOKEN_VALIDITY_IN_MILLISECONDS}
+
+
+springdoc:
+  swagger-ui:
+    path: /swagger-ui/index.html
+    enabled: true
+
+  api-docs:
+    enabled: true
 
 server:
   port: 8080


### PR DESCRIPTION
# ✨ 구현한 내용
Swagger 생성 및 설정
<br><br>

### 변경 사항
- build.gradle에 종속성 추가 
` 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'`
- SwaggerConfig 추가
- WebSecurityConfig의 requestMatchers에 "/v3/api-docs/**", "/swagger-ui/**" 추가
- application.yml 파일에 springdoc 관련 설정
<br><br>


# ✅ 테스트 내용
- swagger ui 와 회원가입 테스트 작동 확인

📎 테스트 결과 스크린샷 
![스크린샷 2025-02-03 225459](https://github.com/user-attachments/assets/960db2a6-1044-4d2a-bbe2-a64406ec3378)
![스크린샷 2025-02-03 225609](https://github.com/user-attachments/assets/053055ec-8bc5-4a0f-90cf-e45657d59e8f)

<br><br>


# 📌 중점 리뷰 사항
- 테스트를 진행하면서 application.yml에 나와있는 JWT_SECRET 환경 변수를 임의로 설정했는데, 그래도 상관없을지 궁금합니다.
- SwaggerConfig에서 jwtSchemeName 를 "JWT TOKEN"으로 설정했는데, 찾아보니 "Authorization" 또는 "Bearer"를 사용하는 경우도 많다고 해서 수정해야할지 확인해주시면 좋을 것 같습니다.
<br><br>


# 🪪 이슈번호 : [#13 ]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @jiwonniy @yina00 
