### PR TITLE
[#25 Feat] 불법주정차 단속 구역 신고

### DIFF
--- a/parker/build.gradle
+++ b/parker/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	//Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	// s3
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/AmazonConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/AmazonConfig.java
@@ -1,0 +1,56 @@
+package com.si9nal.parker.global.common.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@Getter
+public class AmazonConfig {
+    private AWSCredentials awsCredentials;
+
+    @Value("${cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.s3.path.report}")
+    private String reportPath;
+
+
+
+    @PostConstruct
+    public void init() {
+        this.awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+
+    @Bean
+    public AWSCredentialsProvider awsCredentialsProvider() {
+        return new AWSStaticCredentialsProvider(awsCredentials);
+    }
+
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/s3/AmazonS3Manager.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/s3/AmazonS3Manager.java
@@ -1,0 +1,54 @@
+package com.si9nal.parker.global.common.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.si9nal.parker.global.common.config.AmazonConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AmazonS3Manager {
+
+    private final AmazonS3 amazonS3;
+
+    private final AmazonConfig amazonConfig;
+
+    private final UuidRepository uuidRepository;
+
+    public String generateReportKeyName(Uuid uuid) {
+        return amazonConfig.getReportPath() + '/' + uuid.getUuid();
+    }
+
+
+
+    public String uploadFile(String keyName, MultipartFile file) {
+        System.out.println(keyName);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(file.getSize());
+
+        // 파일의 MIME 타입을 설정합니다.
+        String contentType = file.getContentType();
+        if (contentType != null) {
+            metadata.setContentType(contentType);
+        } else {
+            // MIME 타입을 알 수 없는 경우 기본값을 설정합니다.
+            metadata.setContentType("application/octet-stream");
+        }
+
+        try {
+            amazonS3.putObject(new PutObjectRequest(amazonConfig.getBucket(), keyName, file.getInputStream(), metadata));
+        } catch (IOException e) {
+            log.error("error at AmazonS3Manager uploadFile : {}", (Object) e.getStackTrace());
+        }
+
+        return amazonS3.getUrl(amazonConfig.getBucket(), keyName).toString();
+    }
+
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/s3/Uuid.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/s3/Uuid.java
@@ -1,0 +1,19 @@
+package com.si9nal.parker.global.common.s3;
+
+import com.si9nal.parker.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Uuid extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private String uuid;
+}

--- a/parker/src/main/java/com/si9nal/parker/global/common/s3/UuidRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/s3/UuidRepository.java
@@ -1,0 +1,6 @@
+package com.si9nal.parker.global.common.s3;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UuidRepository extends JpaRepository<Uuid, Long> {
+}

--- a/parker/src/main/java/com/si9nal/parker/report/controller/ReportController.java
+++ b/parker/src/main/java/com/si9nal/parker/report/controller/ReportController.java
@@ -1,0 +1,61 @@
+package com.si9nal.parker.report.controller;
+
+
+import com.si9nal.parker.global.common.apiPayload.ApiResponse;
+import com.si9nal.parker.global.common.apiPayload.code.status.SuccessStatus;
+import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
+import com.si9nal.parker.report.dto.req.ReportPostRequestDto;
+import com.si9nal.parker.report.dto.res.ReportPostResponseDto;
+import com.si9nal.parker.report.service.ReportPostService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import static org.apache.tomcat.util.http.fileupload.FileUploadBase.MULTIPART_FORM_DATA;
+
+@RestController
+@RequestMapping("/api/report")
+@Tag(name = "불법주정차 구역 신고 API", description = "불법 주정차 단속 구역을 신고 기능을 제공하는 API")
+public class ReportController {
+    private final ReportPostService reportService;
+
+    public ReportController(ReportPostService reportService) {
+        this.reportService = reportService;
+    }
+
+    @PostMapping(consumes = MULTIPART_FORM_DATA,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    @Operation(summary = "불법주정차 구역 신고 API",
+            description = "불법주정차 단속 구역을 신고하는 API입니다.")
+    @ApiResponses(value = {
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "불법주정차 구역 신고 성공",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = ParkingSpaceMapDto.class)
+                    )
+            ),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청"
+            )
+    })
+    public ResponseEntity<ApiResponse<ReportPostResponseDto>> postReport(
+            @AuthenticationPrincipal String email,
+            @ModelAttribute ReportPostRequestDto request) {
+
+        ReportPostResponseDto response = reportService.createReport(email, request);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(SuccessStatus._OK, response)
+        );
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/report/domain/Report.java
+++ b/parker/src/main/java/com/si9nal/parker/report/domain/Report.java
@@ -4,14 +4,13 @@ import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.report.domain.enums.ApprovalStatus;
 import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Report extends BaseEntity {
     @Id
@@ -29,6 +28,4 @@ public class Report extends BaseEntity {
     private ApprovalStatus approvalStatus = ApprovalStatus.PENDING;
 
     private String imageUrl;
-
-
 }

--- a/parker/src/main/java/com/si9nal/parker/report/dto/req/ReportPostRequestDto.java
+++ b/parker/src/main/java/com/si9nal/parker/report/dto/req/ReportPostRequestDto.java
@@ -4,6 +4,7 @@ import com.si9nal.parker.report.domain.Report;
 import com.si9nal.parker.report.domain.enums.ApprovalStatus;
 import com.si9nal.parker.user.domain.User;
 import com.si9nal.parker.user.domain.enums.Status;
+import jakarta.persistence.Column;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.web.multipart.MultipartFile;
@@ -13,6 +14,11 @@ import org.springframework.web.multipart.MultipartFile;
 public class ReportPostRequestDto {
     private String address;
     private MultipartFile image; // Optional image file
+
+    // null 체크 메서드 추가
+    public boolean hasImage() {
+        return image != null && !image.isEmpty();
+    }
 
     public Report toEntity() {
         return Report.builder()

--- a/parker/src/main/java/com/si9nal/parker/report/dto/req/ReportPostRequestDto.java
+++ b/parker/src/main/java/com/si9nal/parker/report/dto/req/ReportPostRequestDto.java
@@ -1,0 +1,23 @@
+package com.si9nal.parker.report.dto.req;
+
+import com.si9nal.parker.report.domain.Report;
+import com.si9nal.parker.report.domain.enums.ApprovalStatus;
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.domain.enums.Status;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+public class ReportPostRequestDto {
+    private String address;
+    private MultipartFile image; // Optional image file
+
+    public Report toEntity() {
+        return Report.builder()
+                .address(this.address)
+                .approvalStatus(ApprovalStatus.PENDING)
+                .build();
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/report/dto/res/ReportPostResponseDto.java
+++ b/parker/src/main/java/com/si9nal/parker/report/dto/res/ReportPostResponseDto.java
@@ -1,0 +1,25 @@
+package com.si9nal.parker.report.dto.res;
+
+
+import com.si9nal.parker.report.domain.Report;
+import com.si9nal.parker.report.domain.enums.ApprovalStatus;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReportPostResponseDto {
+    private Long id;
+    private String address;
+    private ApprovalStatus approvalStatus;
+    private String imageUrl;
+
+    public static ReportPostResponseDto fromEntity(Report report) {
+        ReportPostResponseDto dto = new ReportPostResponseDto();
+        dto.setId(report.getId());
+        dto.setAddress(report.getAddress());
+        dto.setApprovalStatus(report.getApprovalStatus());
+        dto.setImageUrl(report.getImageUrl());
+        return dto;
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/report/repository/ReportRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/report/repository/ReportRepository.java
@@ -1,0 +1,10 @@
+package com.si9nal.parker.report.repository;
+
+import com.si9nal.parker.report.domain.Report;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+}

--- a/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
+++ b/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
@@ -23,14 +23,21 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.UUID;
 
 @Service
-@RequiredArgsConstructor
+@Transactional
 public class ReportPostService {
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
 
-    @Transactional
+    public ReportPostService(ReportRepository reportRepository, UserRepository userRepository, AmazonS3Manager s3Manager, UuidRepository uuidRepository) {
+        this.reportRepository = reportRepository;
+        this.userRepository = userRepository;
+        this.s3Manager = s3Manager;
+        this.uuidRepository = uuidRepository;
+    }
+
+
     public ReportPostResponseDto createReport(String email, ReportPostRequestDto requestDto) {
 
         User user = userRepository.findByEmail(email)

--- a/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
+++ b/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
@@ -47,8 +47,7 @@ public class ReportPostService {
         Report report = requestDto.toEntity();
         report.setUser(user);
 
-        MultipartFile image = requestDto.getImage();
-        if (image != null && !image.isEmpty()) {
+        if (requestDto.hasImage()) {
             Uuid imgUuid = uuidRepository.save(Uuid.builder().uuid(UUID.randomUUID().toString()).build());
             String imgURL = s3Manager.uploadFile(s3Manager.generateReportKeyName(imgUuid), requestDto.getImage());
             report.setImageUrl(imgURL);

--- a/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
+++ b/parker/src/main/java/com/si9nal/parker/report/service/ReportPostService.java
@@ -1,0 +1,54 @@
+package com.si9nal.parker.report.service;
+
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
+import com.si9nal.parker.global.common.s3.AmazonS3Manager;
+import com.si9nal.parker.global.common.s3.Uuid;
+import com.si9nal.parker.global.common.s3.UuidRepository;
+import com.si9nal.parker.report.domain.Report;
+import com.si9nal.parker.report.domain.enums.ApprovalStatus;
+
+import com.si9nal.parker.report.dto.req.ReportPostRequestDto;
+import com.si9nal.parker.report.dto.res.ReportPostResponseDto;
+import com.si9nal.parker.report.repository.ReportRepository;
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ReportPostService {
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+    private final AmazonS3Manager s3Manager;
+    private final UuidRepository uuidRepository;
+
+    @Transactional
+    public ReportPostResponseDto createReport(String email, ReportPostRequestDto requestDto) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // Create report
+        Report report = requestDto.toEntity();
+        report.setUser(user);
+
+        MultipartFile image = requestDto.getImage();
+        if (image != null && !image.isEmpty()) {
+            Uuid imgUuid = uuidRepository.save(Uuid.builder().uuid(UUID.randomUUID().toString()).build());
+            String imgURL = s3Manager.uploadFile(s3Manager.generateReportKeyName(imgUuid), requestDto.getImage());
+            report.setImageUrl(imgURL);
+        }
+
+        // Save and return
+        Report savedReport = reportRepository.save(report);
+        return ReportPostResponseDto.fromEntity(savedReport);
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/user/repository/UserRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    Optional<User> findById(Long userId);
 }

--- a/parker/src/main/resources/application.yml
+++ b/parker/src/main/resources/application.yml
@@ -31,5 +31,19 @@ springdoc:
   api-docs:
     enabled: true
 
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+      path:
+        report : reports
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY_ID}
+      secretKey: ${AWS_SECRET_ACCESS_KEY}
+
 server:
   port: 8080


### PR DESCRIPTION
# ✨ 구현한 내용
불법주정차 단속 구역 신고 API
<br><br>

### 불법주정차 단속 구역 신고 API
- /api/report 엔트포인트 연결하여 사용자가 주소와 이미지 파일(선택)을 포함하여 요청하면, 사용자를 식별하여 신고 기록을 저장함
- aws s3 사용하여 나타냄
 - AmazonConfig와 global/common/aws/s3 폴더에 필요한 파일 추가
 - 신고 사진은 버킷 내 reports 폴더로 설정
 - Uuid 설정하여 파일이름이 유니크하도록 설정
</br></br>


# ✅ 테스트 내용
- Swagger로 불법 주정차 신고 api 테스트. image가 null일때와 들어있을때, aws에서 정상적으로 보이는 지 확인


📎 테스트 결과 스크린샷 (선택)
- 성공시
![스크린샷 2025-02-08 011719](https://github.com/user-attachments/assets/2fee5fbf-f080-452f-8e57-a91fbe1ed5dc)
![스크린샷 2025-02-08 011738](https://github.com/user-attachments/assets/cdb98f2c-9f85-42dc-88ea-4ae450112d04)
![스크린샷 2025-02-08 011806](https://github.com/user-attachments/assets/5c2c458b-859d-4ff4-a67e-f45aa955e8ec)
- null 처리
![스크린샷 2025-02-08 021818](https://github.com/user-attachments/assets/bfaeb895-8a21-4336-93a7-5ebaae76a34f)
<br><br>


# 📌 중점 리뷰 사항
- image가 null일때도 정상 동작하도록 설정해놨는데 notnull로 해야하는지 궁금합니다.
- aws s3 설정은 어떤 계정을 사용할지 아직 안정했던 것 같아 일단 제 계정을 사용해서 설정해뒀습니다. 어떤 계정 사용할지 회의시간에 정하면 좋을 것 같습니다.
- 피그마 상엔 주소 검색 칸이 있는데 프론트에서 구현하는건지 백에서 구현하는건지 몰라 일단 구현하지 않았는데 구현해야할 지 궁금합니다.
<br><br>


# 🪪 이슈번호 : [#25 ]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @jiwonniy @yina00 
