### PR TITLE
[#30 Chore] 프론트 URL CORS 설정 허용

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DataSourceManagerImpl" format="xml" multifile-model="true">
-      <data-source source="LOCAL" name="@localhost" uuid="d14ca6bf-4d1e-4524-a945-4f0e4c29971b">
+    <data-source source="LOCAL" name="@localhost" uuid="d14ca6bf-4d1e-4524-a945-4f0e4c29971b">
       <driver-ref>mysql.8</driver-ref>
       <synchronize>true</synchronize>
       <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
@@ -9,12 +9,29 @@
       <jdbc-additional-properties>
         <property name="com.intellij.clouds.kubernetes.db.host.port" />
         <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
         <property name="com.intellij.clouds.kubernetes.db.container.port" />
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
       <driver-properties>
         <property name="allowLoadLocalInfile" value="TRUE" />
       </driver-properties>
+    </data-source>
+    <data-source source="LOCAL" name="mysql" uuid="9e00f522-4143-4efa-b96c-9013a64c1bac">
+      <driver-ref>mysql.8</driver-ref>
+      <synchronize>true</synchronize>
+      <imported>true</imported>
+      <configured-by-url>true</configured-by-url>
+      <remarks>$PROJECT_DIR$/parker/src/main/resources/application.yml</remarks>
+      <jdbc-driver>com.mysql.cj.jdbc.Driver</jdbc-driver>
+      <jdbc-url>0718</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.resource.type" value="Deployment" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
   </component>
 </project>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="MarkedForRemoval" enabled="false" level="ERROR" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <list size="2">
+      <item index="0" class="java.lang.String" itemvalue="org.springframework.boot.test.mock.mockito.MockBean" />
+      <item index="1" class="java.lang.String" itemvalue="org.springframework.boot.test.mock.mockito.MockBean" />
+    </list>
+  </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$/parker" />

--- a/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/config/WebSecurityConfig.java
@@ -12,6 +12,11 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.Arrays;
+import java.util.List;
 
 @RequiredArgsConstructor
 @Configuration
@@ -24,6 +29,7 @@ public class WebSecurityConfig {
         return http
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(corsConfigurationSource())) // CORS 설정 추가
                 .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -36,6 +42,23 @@ public class WebSecurityConfig {
                 )
                 .addFilterBefore(new JwtFilter(tokenprovider), UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    // CORS 설정을 위한 Bean 추가
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOriginPatterns(List.of("http://localhost:3000"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Access-Control-Allow-Credentials", "Authorization", "Content-Type"));
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 
     @Bean

--- a/parker/src/test/java/com/si9nal/parker/global/common/config/WebSecurityConfigTest.java
+++ b/parker/src/test/java/com/si9nal/parker/global/common/config/WebSecurityConfigTest.java
@@ -1,0 +1,86 @@
+package com.si9nal.parker.global.common.config;
+
+import com.si9nal.parker.ParkerApplication;
+import com.si9nal.parker.global.common.security.TokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(classes = ParkerApplication.class)
+@AutoConfigureMockMvc
+@Transactional
+@TestPropertySource(locations = "classpath:application.yml")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WebSecurityConfigTest {
+
+    @MockBean
+    private TokenProvider tokenProvider;  // TokenProvider를 MockBean으로 등록
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @DisplayName("CORS Preflight 요청 테스트 - 허용된 Origin")
+    void corsPreflightWithAllowedOrigin() throws Exception {
+        // given
+        String allowedOrigin = "http://localhost:3000";
+
+        // when
+        ResultActions result = mockMvc.perform(options("/api/user/signup")
+                .header("Origin", allowedOrigin)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Authorization"));
+
+        // then
+        result.andExpect(status().isOk())
+                .andExpect(header().string("Access-Control-Allow-Origin", allowedOrigin))
+                .andExpect(header().string("Access-Control-Allow-Methods", "GET,POST,PUT,PATCH,DELETE,OPTIONS"))
+                .andExpect(header().exists("Access-Control-Allow-Headers"))
+                .andExpect(header().string("Access-Control-Allow-Credentials", "true"))
+                .andExpect(header().exists("Access-Control-Max-Age"));
+    }
+
+    @Test
+    @DisplayName("CORS Preflight 요청 테스트 - 허용되지 않은 Origin")
+    void corsPreflightWithNotAllowedOrigin() throws Exception {
+        // given
+        String notAllowedOrigin = "http://malicious-site.com";
+
+        // when
+        ResultActions result = mockMvc.perform(options("/api/user/signup")
+                .header("Origin", notAllowedOrigin)
+                .header("Access-Control-Request-Method", "POST")
+                .header("Access-Control-Request-Headers", "Authorization"));
+
+        // then
+        result.andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("CORS Preflight 요청 테스트 - 허용되지 않은 HTTP 메소드")
+    void corsPreflightWithNotAllowedMethod() throws Exception {
+        // given
+        String allowedOrigin = "http://localhost:3000";
+
+        // when
+        ResultActions result = mockMvc.perform(options("/api/user/signup")
+                .header("Origin", allowedOrigin)
+                .header("Access-Control-Request-Method", "TRACE")
+                .header("Access-Control-Request-Headers", "Authorization"));
+
+        // then
+        result.andExpect(status().isForbidden());
+    }
+}

--- a/parker/src/test/resources/application.yml
+++ b/parker/src/test/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: parker
 
   datasource:
-    url: ${DB_TEST_URL}
+    url: jdbc:mysql://localhost:3306/parker_test
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -12,12 +12,20 @@ spring:
     database: mysql
     database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
-      ddl-auto: create-drop  # 테스트마다 DB 초기화
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:
         format_sql: true
         use_sql_comments: true
 
+jwt:
+  secret: ${JWT_SECRET}
+  token-validity-in-milliseconds: 3600000
+
 server:
   port: 8080
+
+logging:
+  level:
+    org.springframework: DEBUG

--- a/parker/src/test/resources/application.yml
+++ b/parker/src/test/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: parker
 
   datasource:
-    url: jdbc:mysql://localhost:3306/parker_test
+    url: ${DB_TEST_URL}
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
# ✨ 구현한 내용
프론트에서 사용하는 3000 포트에서 접근할 수 있도록 CORS 설정을 추가했습니다.
<br><br>

### CORS 설정
- WebSecurityConfig에서 http://localhost:3000 허용

📎 샘플 데이터 (선택)
ex. 반환되는 코드 결과 스크린샷
<br><br>


# ✅ 테스트 내용
- 실행해서 확인할 수가 없어 허용된 url, 허용되지 않은 url, 허용되지 않은 http 메소드에 대해 테스트 진행

📎 테스트 결과 스크린샷 (선택)
![스크린샷 2025-02-09 203531](https://github.com/user-attachments/assets/145101db-a4eb-4fea-a62b-97003a8df7a6)

<br><br>


# 📌 중점 리뷰 사항
- setExposedHeaders에서 어느걸 허용해줘야할지 몰라 일단 임의로 추가하였는데, 맞는지 확인 부탁드립니다.
- 이외의 설정에도 더 추가해야할게 있는지 봐주시면 감사하겠습니다.
- 프론트에서 테스트를 위해 요청한 사안이라 리뷰가 완료되는대로 바로 머지해도 될지 궁금합니다.
<br><br>


# 🪪 이슈번호 : [#30 ]
<br><br>


# 🙋‍♂️ 리뷰어
@jiwonniy @seun0123 @yina00 
