### PR TITLE
[#34 Feat] 위치 즐겨찾기 추가 및 삭제

### DIFF
--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -1,0 +1,43 @@
+package com.si9nal.parker.bookmark.controller;
+
+import com.si9nal.parker.bookmark.dto.res.SpaceBookmarkResDto;
+import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
+import com.si9nal.parker.bookmark.service.BookmarkService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/bookmark")
+@RequiredArgsConstructor
+public class BookmarkController {
+    private final BookmarkService bookmarkService;
+
+    @PostMapping("/parking-violation/{id}")
+    public ResponseEntity<ViolationBookmarkResDto> toggleViolationBookmark(
+
+            @AuthenticationPrincipal String email,
+            @PathVariable Long id
+    ) {
+
+            ViolationBookmarkResDto violationBookmarkResponse = bookmarkService.toggleViolationBookmark(email, id);
+            return ResponseEntity.ok(violationBookmarkResponse);
+
+    }
+
+    @PostMapping("/parking-space/{id}")
+    public ResponseEntity<SpaceBookmarkResDto> toggleSpaceBookmark(
+
+            @AuthenticationPrincipal String email,
+            @PathVariable Long id
+    ) {
+
+        SpaceBookmarkResDto spaceBookmarkResponse = bookmarkService.toggleSpaceBookmark(email, id);
+        return ResponseEntity.ok(spaceBookmarkResponse);
+
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/domain/SpaceBookmark.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/domain/SpaceBookmark.java
@@ -4,16 +4,15 @@ import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.parkingspace.domain.ParkingSpace;
 import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class SpaceBookmark extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/parker/src/main/java/com/si9nal/parker/bookmark/domain/ViolationBookmark.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/domain/ViolationBookmark.java
@@ -4,16 +4,15 @@ import com.si9nal.parker.global.common.BaseEntity;
 import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
 import com.si9nal.parker.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ViolationBookmark extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/SpaceBookmarkResDto.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/SpaceBookmarkResDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SpaceBookmarkResDto {
-    private boolean isBookmarked; // 북마크 상태 확인용
+    private boolean isBookmarked;
     private Long parkingSpaceId;
     private String parkingName;
 

--- a/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/SpaceBookmarkResDto.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/SpaceBookmarkResDto.java
@@ -1,0 +1,21 @@
+package com.si9nal.parker.bookmark.dto.res;
+
+import com.si9nal.parker.parkingspace.domain.ParkingSpace;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpaceBookmarkResDto {
+    private boolean isBookmarked; // 북마크 상태 확인용
+    private Long parkingSpaceId;
+    private String parkingName;
+
+    public static SpaceBookmarkResDto of(boolean isBookmarked, ParkingSpace parkingSpace) {
+        return new SpaceBookmarkResDto(
+                isBookmarked,
+                parkingSpace.getId(),
+                parkingSpace.getParkingName()
+        );
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/ViolationBookmarkResDto.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/ViolationBookmarkResDto.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ViolationBookmarkResDto {
-    private boolean isBookmarked; // 북마크 상태 확인용
+    private boolean isBookmarked;
     private Long parkingViolationId;
     private String detailedLocation;
 

--- a/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/ViolationBookmarkResDto.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/dto/res/ViolationBookmarkResDto.java
@@ -1,0 +1,21 @@
+package com.si9nal.parker.bookmark.dto.res;
+
+import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ViolationBookmarkResDto {
+    private boolean isBookmarked; // 북마크 상태 확인용
+    private Long parkingViolationId;
+    private String detailedLocation;
+
+    public static ViolationBookmarkResDto of(boolean isBookmarked, ParkingViolation parkingViolation) {
+        return new ViolationBookmarkResDto(
+                isBookmarked,
+                parkingViolation.getId(),
+                parkingViolation.getDetailedLocation()
+        );
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
@@ -6,9 +6,12 @@ import com.si9nal.parker.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface SpaceBookmarkRepository extends JpaRepository<SpaceBookmark, Long> {
 
     boolean existsByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
 
+    Optional<SpaceBookmark> findByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/ViolationBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/ViolationBookmarkRepository.java
@@ -1,0 +1,14 @@
+package com.si9nal.parker.bookmark.repository;
+
+import com.si9nal.parker.bookmark.domain.ViolationBookmark;
+import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
+import com.si9nal.parker.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ViolationBookmarkRepository extends JpaRepository<ViolationBookmark, Long> {
+    Optional<ViolationBookmark> findByUserAndParkingViolation(User user, ParkingViolation parkingViolation);
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
@@ -1,0 +1,83 @@
+package com.si9nal.parker.bookmark.service;
+
+import com.si9nal.parker.bookmark.domain.SpaceBookmark;
+import com.si9nal.parker.bookmark.domain.ViolationBookmark;
+import com.si9nal.parker.bookmark.dto.res.SpaceBookmarkResDto;
+import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
+import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
+import com.si9nal.parker.bookmark.repository.ViolationBookmarkRepository;
+import com.si9nal.parker.parkingspace.domain.ParkingSpace;
+import com.si9nal.parker.parkingspace.repository.ParkingSpaceRepository;
+import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
+import com.si9nal.parker.parkingviolation.repository.ParkingViolationRepository;
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BookmarkService {
+    private final ViolationBookmarkRepository violationBookmarkRepository;
+    private final ParkingViolationRepository parkingViolationRepository;
+    private final SpaceBookmarkRepository spaceBookmarkRepository;
+    private final ParkingSpaceRepository parkingSpaceRepository;
+    private final UserRepository userRepository;
+    private static final Logger logger = LoggerFactory.getLogger(BookmarkService.class);
+
+    public ViolationBookmarkResDto toggleViolationBookmark(String email, Long parkingViolationId) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+
+        ParkingViolation parkingViolation = parkingViolationRepository.findById(parkingViolationId)
+                .orElseThrow(() -> new EntityNotFoundException("주정차 단속 구간이 없습니다."));
+
+        Optional<ViolationBookmark> existingBookmark = violationBookmarkRepository.findByUserAndParkingViolation(user, parkingViolation);
+
+        if (existingBookmark.isPresent()) {
+            violationBookmarkRepository.delete(existingBookmark.get());
+            return ViolationBookmarkResDto.of(false, parkingViolation);
+        } else {
+            ViolationBookmark newBookmark = ViolationBookmark.builder()
+                    .user(user)
+                    .parkingViolation(parkingViolation)
+                    .build();
+
+            violationBookmarkRepository.save(newBookmark);
+            return ViolationBookmarkResDto.of(true, parkingViolation);
+        }
+    }
+
+    public SpaceBookmarkResDto toggleSpaceBookmark(String email, Long parkingSpaceId) {
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+
+        ParkingSpace parkingSpace = parkingSpaceRepository.findById(parkingSpaceId)
+                .orElseThrow(() -> new EntityNotFoundException("주차장 조회에 실패했습니다."));
+
+        Optional<SpaceBookmark> existingBookmark = spaceBookmarkRepository.findByUserAndParkingSpace(user, parkingSpace);
+
+        if (existingBookmark.isPresent()) {
+            spaceBookmarkRepository.delete(existingBookmark.get());
+            return SpaceBookmarkResDto.of(false, parkingSpace);
+        } else {
+            SpaceBookmark newSpaceBookmark = SpaceBookmark.builder()
+                    .user(user)
+                    .parkingSpace(parkingSpace)
+                    .build();
+
+            spaceBookmarkRepository.save(newSpaceBookmark);
+            return SpaceBookmarkResDto.of(true, parkingSpace);
+        }
+    }
+
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
@@ -14,8 +14,6 @@ import com.si9nal.parker.user.domain.User;
 import com.si9nal.parker.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,7 +28,6 @@ public class BookmarkService {
     private final SpaceBookmarkRepository spaceBookmarkRepository;
     private final ParkingSpaceRepository parkingSpaceRepository;
     private final UserRepository userRepository;
-    private static final Logger logger = LoggerFactory.getLogger(BookmarkService.class);
 
     public ViolationBookmarkResDto toggleViolationBookmark(String email, Long parkingViolationId) {
 
@@ -38,7 +35,7 @@ public class BookmarkService {
                 .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
 
         ParkingViolation parkingViolation = parkingViolationRepository.findById(parkingViolationId)
-                .orElseThrow(() -> new EntityNotFoundException("주정차 단속 구간이 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("주정차 단속 구간 조회에 실패했습니다."));
 
         Optional<ViolationBookmark> existingBookmark = violationBookmarkRepository.findByUserAndParkingViolation(user, parkingViolation);
 


### PR DESCRIPTION
# ✨ 구현한 내용

- 로그인 사용자의 정보를 인식한다.
- 주차공간 즐겨찾기를 추가한다.
- 주차공간 즐겨찾기를 삭제한다.
- 불법 주정차 구역 위치 즐겨찾기를 추가한다.
- 불법 주정차 구역 위치 즐겨찾기를 삭제한다.

<br><br>

### 1. 로그인 사용자의 정보 인식
- 엔드포인트 /api/bookmark/parking-violation/{id} 와 /api/bookmark/parking-space/{id} 로 들어올 때 
   @AuthenticationPrincipal String email, @PathVariable Long id 로 받아온다.

### 2. 불법 주정차 구역 위치 즐겨찾기 추가 및 삭제
- 엔드포인드 /api/bookmark/parking-violation/{id} 로 연결
- toggleViolationBookmark 메서드 정의
  - 사용자와 불법 주정차 구역 객체 조회와 객체 생성, 조회 실패 시 에러 발생
  - 불법주정차 즐겨찾기 db 조회 시 존재하면 삭제, 비어있으면 저장

### 3. 주차공간 위치 즐겨찾기 추가 및 삭제
- 엔드포인드 /api/bookmark/parking-space/{id} 로 연결
- toggleSpaceBookmark 메서드 정의
  (불법 주정차 구역과 동일한 로직)


📎 샘플 데이터 (선택)
<br><br>


# ✅ 테스트 내용

📎 테스트 결과 스크린샷 (선택)
- 불법 주정차 구역 즐겨찾기 추가
![image](https://github.com/user-attachments/assets/f08ba8c8-9557-4038-964f-47f91270f80e)

- 불법 주정차 구역 즐겨찾기 삭제
![image](https://github.com/user-attachments/assets/1142f3d0-092f-4cba-92e8-bdbce6577d35)

- 주차 공간 즐겨찾기 추가
![image](https://github.com/user-attachments/assets/08605b81-3253-47f0-8dae-95477d942fd1)

- 주차 공간 즐겨찾기 삭제
![image](https://github.com/user-attachments/assets/7cce586f-2bb2-4179-b188-8de0c7e51aad)

- 주차 공간 조회 실패
![image](https://github.com/user-attachments/assets/4133561e-5490-4279-8624-4d4ba048802d)

- 불법 주정차 구역 조회 실패
![image](https://github.com/user-attachments/assets/afc0eccd-1e82-47d4-99be-777f535cedbb)

<br><br>


# 📌 중점 리뷰 사항
- 로그인 한 사용자를 불러오는 방법으로 @AuthenticationPrincipal 로 User 객체를 불러오려고 했는데 계획대로 잘 되지 않아 report 파트에서 사용하신 방법을 참고하여 개발했습니다. 
로직이 맞는지 확인부탁드립니다!
- 응답 구조 통일과 예외 처리 보완 과정에서 Swagger를 사용하여 문서화 및 테스트까지 진행하겠습니다.
- 늦어서 죄송합니다..!🙏
<br><br>

# 🪪 이슈번호 : [#34 ]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @bigtr3 @jiwonniy 
