### PR TITLE
[#41 Feat] 주차 구역 즐겨찾기 조회 및 정렬

### DIFF
--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -3,19 +3,21 @@ package com.si9nal.parker.bookmark.controller;
 import com.si9nal.parker.bookmark.dto.res.SpaceBookmarkResDto;
 import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
 import com.si9nal.parker.bookmark.service.BookmarkService;
+import com.si9nal.parker.bookmark.service.BookmarkListService;
+import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/bookmark")
 @RequiredArgsConstructor
 public class BookmarkController {
     private final BookmarkService bookmarkService;
+    private final BookmarkListService bookmarkListService;
 
     @PostMapping("/parking-violation/{id}")
     public ResponseEntity<ViolationBookmarkResDto> toggleViolationBookmark(
@@ -39,5 +41,13 @@ public class BookmarkController {
         SpaceBookmarkResDto spaceBookmarkResponse = bookmarkService.toggleSpaceBookmark(email, id);
         return ResponseEntity.ok(spaceBookmarkResponse);
 
+    }
+
+    @GetMapping("/parking-space-list")
+    public ResponseEntity<List<ParkingSpaceMapDto>> getParkingSpaceList (
+            @AuthenticationPrincipal String email
+    ) {
+        List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email);
+        return ResponseEntity.ok(parkingSpaceListResponse);
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -21,7 +21,7 @@ public class BookmarkController {
 
     @PostMapping("/parking-violation/{id}")
     public ResponseEntity<ViolationBookmarkResDto> toggleViolationBookmark(
-
+            
             @AuthenticationPrincipal String email,
             @PathVariable Long id
     ) {
@@ -43,11 +43,12 @@ public class BookmarkController {
 
     }
 
-    @GetMapping("/parking-space-list")
+    @GetMapping("/parking-space-list/{type}")
     public ResponseEntity<List<ParkingSpaceMapDto>> getParkingSpaceList (
-            @AuthenticationPrincipal String email
+            @AuthenticationPrincipal String email,
+            @PathVariable String type
     ) {
-        List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email);
+        List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email, type);
         return ResponseEntity.ok(parkingSpaceListResponse);
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -43,12 +43,12 @@ public class BookmarkController {
 
     }
 
-    @GetMapping("/parking-space-list/{type}")
+    @GetMapping("/parking-space-list")
     public ResponseEntity<List<ParkingSpaceMapDto>> getParkingSpaceList (
             @AuthenticationPrincipal String email,
-            @PathVariable String type
+            @RequestParam(required = false, defaultValue = "latest") String sort
     ) {
-        List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email, type);
+        List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email, sort);
         return ResponseEntity.ok(parkingSpaceListResponse);
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
@@ -6,6 +6,7 @@ import com.si9nal.parker.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +15,5 @@ public interface SpaceBookmarkRepository extends JpaRepository<SpaceBookmark, Lo
     boolean existsByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
 
     Optional<SpaceBookmark> findByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
+    List<SpaceBookmark> findByUser(User user);
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
@@ -16,4 +16,6 @@ public interface SpaceBookmarkRepository extends JpaRepository<SpaceBookmark, Lo
 
     Optional<SpaceBookmark> findByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
     List<SpaceBookmark> findByUser(User user);
+    List<SpaceBookmark> findByUserOrderByCreatedAtAsc(User user);
+    List<SpaceBookmark> findByUserOrderByCreatedAtDesc(User user);
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -1,0 +1,31 @@
+package com.si9nal.parker.bookmark.service;
+
+import com.si9nal.parker.bookmark.domain.SpaceBookmark;
+import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
+import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
+import com.si9nal.parker.user.domain.User;
+import com.si9nal.parker.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class BookmarkListService {
+    private final SpaceBookmarkRepository spaceBookmarkRepository;
+    private final UserRepository userRepository;
+
+    public List<ParkingSpaceMapDto> getParkingSpaceList(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+        List<SpaceBookmark> spaceBookmarks = spaceBookmarkRepository.findByUser(user);
+
+        return spaceBookmarks.stream()
+                .map(SpaceBookmark -> ParkingSpaceMapDto.fromEntity(SpaceBookmark.getParkingSpace()))
+                .collect(Collectors.toList());
+
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -18,15 +18,15 @@ public class BookmarkListService {
     private final SpaceBookmarkRepository spaceBookmarkRepository;
     private final UserRepository userRepository;
 
-    public List<ParkingSpaceMapDto> getParkingSpaceList(String email, String type) {
+    public List<ParkingSpaceMapDto> getParkingSpaceList(String email, String sort) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
 
         List<SpaceBookmark> spaceBookmarks;
 
-        if("earliest".equals(type)) {
+        if("earliest".equals(sort)) {
             spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
-        } else if ("latest".equals(type)) {
+        } else if ("latest".equals(sort)) {
             spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtDesc(user);
         } else {
             spaceBookmarks = spaceBookmarkRepository.findByUser(user); // 에러 추가 예정

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -18,14 +18,22 @@ public class BookmarkListService {
     private final SpaceBookmarkRepository spaceBookmarkRepository;
     private final UserRepository userRepository;
 
-    public List<ParkingSpaceMapDto> getParkingSpaceList(String email) {
+    public List<ParkingSpaceMapDto> getParkingSpaceList(String email, String type) {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
-        List<SpaceBookmark> spaceBookmarks = spaceBookmarkRepository.findByUser(user);
+
+        List<SpaceBookmark> spaceBookmarks;
+
+        if("earliest".equals(type)) {
+            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
+        } else if ("latest".equals(type)) {
+            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtDesc(user);
+        } else {
+            spaceBookmarks = spaceBookmarkRepository.findByUser(user);
+        }
 
         return spaceBookmarks.stream()
                 .map(SpaceBookmark -> ParkingSpaceMapDto.fromEntity(SpaceBookmark.getParkingSpace()))
                 .collect(Collectors.toList());
-
     }
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -29,7 +29,7 @@ public class BookmarkListService {
         } else if ("latest".equals(type)) {
             spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtDesc(user);
         } else {
-            spaceBookmarks = spaceBookmarkRepository.findByUser(user);
+            spaceBookmarks = spaceBookmarkRepository.findByUser(user); // 에러 추가 예정
         }
 
         return spaceBookmarks.stream()


### PR DESCRIPTION
# ✨ 구현한 내용
- 사용자가 자신이 즐겨찾기 한 주차 구역 조회
- 즐겨찾기에 저장한 시간을 기준으로 최신순, 오래된순 조회
- #34 번 이슈 브렌치에서 새로운 브렌치를 생성하여 작업했습니다

<br><br>

### 1. 사용자가 자신이 즐겨찾기 한 주차 구역 조회
- 엔드포인트 /api/bookmark/parking-space-list/{type} 추가 분기문으로 처리
- type 이 earlist 면 오래된순 조회
- type 이 latest 면 최신순 조회

📎 샘플 데이터 (선택)
<br><br>


# ✅ 테스트 내용
- 테스트 내용 설명

📎 테스트 결과 스크린샷 (선택)
- 오래된순
![image](https://github.com/user-attachments/assets/38423544-b16a-44ce-a30b-7a4e31bb6923)

- 최신순
![image](https://github.com/user-attachments/assets/f6eb1b0e-6a7f-4e11-9583-b9a3df918405)

<br><br>


# 📌 중점 리뷰 사항
- 최신순과 오래된순 엔드포인트를 나누었기 때문에 처음 즐겨찾기 조회 시 최신순이나 오래된순으로 자동 선택되게 하면 될 것 같은데, 처음 진입할 때 버튼으로 제공하는 정렬기준 최신순 과 오래된순이 아닌 다른 정렬기준으로 보여주는 것이 좋을 지 확인 부탁드립니다.
- 최신 main 상태를 pull 받고 리팩토링 이슈를 따로 생성해서 개발하기 위해 기능 개발 이후 먼저 pr 보냅니다.
<br><br>


# 🪪 이슈번호 : [#41]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @bigtr3 @jiwonniy 
