### PR TITLE
[#45 Refactor] 즐겨찾기 응답구조 통일, 에러처리, swagger 적용

### DIFF
--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -5,6 +5,10 @@ import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
 import com.si9nal.parker.bookmark.service.BookmarkService;
 import com.si9nal.parker.bookmark.service.BookmarkListService;
 import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "즐겨찾기 API", description = "즐겨찾기 추가, 삭제, 조회 API")
 @RestController
 @RequestMapping("/api/bookmark")
 @RequiredArgsConstructor
@@ -19,33 +24,38 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
     private final BookmarkListService bookmarkListService;
 
+    @Operation(summary = "불법주정차 단속 구역 즐겨찾기 추가 및 삭제", description = "데이터가 존재하면 삭제, 데이터가 존재하지 않으면 추가합니다.")
     @PostMapping("/parking-violation/{id}")
     public ResponseEntity<ViolationBookmarkResDto> toggleViolationBookmark(
-            
             @AuthenticationPrincipal String email,
+            @Parameter (description = "즐겨찾기를 추가/삭제 할 불법주정차 단속 구역 ID", example = "1")
             @PathVariable Long id
     ) {
-
             ViolationBookmarkResDto violationBookmarkResponse = bookmarkService.toggleViolationBookmark(email, id);
             return ResponseEntity.ok(violationBookmarkResponse);
-
     }
 
+    @Operation(summary = "주차공간 즐겨찾기 추가 및 삭제", description = "데이터가 존재하면 삭제, 데이터가 존재하지 않으면 추가합니다.")
     @PostMapping("/parking-space/{id}")
     public ResponseEntity<SpaceBookmarkResDto> toggleSpaceBookmark(
 
             @AuthenticationPrincipal String email,
+            @Parameter (description = "즐겨찾기를 추가/삭제 할 주차공간 ID", example = "1")
             @PathVariable Long id
     ) {
-
         SpaceBookmarkResDto spaceBookmarkResponse = bookmarkService.toggleSpaceBookmark(email, id);
         return ResponseEntity.ok(spaceBookmarkResponse);
-
     }
 
+    @Operation(summary = "즐겨찾기 한 주차공간 조회", description = "최신순, 오래된순 으로 조회할 수 있으며 요청 파라미터 없을 시 기본 최신순으로 조회")
     @GetMapping("/parking-space-list")
     public ResponseEntity<List<ParkingSpaceMapDto>> getParkingSpaceList (
             @AuthenticationPrincipal String email,
+            @Parameter(description = "정렬 방법", examples = {
+                    @ExampleObject(name = "최신순", value = "latest"),
+                    @ExampleObject(name = "오래된순", value = "earliest")
+                }
+            )
             @RequestParam(required = false, defaultValue = "latest") String sort
     ) {
         List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email, sort);

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
@@ -15,7 +15,6 @@ public interface SpaceBookmarkRepository extends JpaRepository<SpaceBookmark, Lo
     boolean existsByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
 
     Optional<SpaceBookmark> findByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
-    List<SpaceBookmark> findByUser(User user);
     List<SpaceBookmark> findByUserOrderByCreatedAtAsc(User user);
     List<SpaceBookmark> findByUserOrderByCreatedAtDesc(User user);
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -2,6 +2,8 @@ package com.si9nal.parker.bookmark.service;
 
 import com.si9nal.parker.bookmark.domain.SpaceBookmark;
 import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
 import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
 import com.si9nal.parker.user.domain.User;
 import com.si9nal.parker.user.repository.UserRepository;
@@ -20,16 +22,16 @@ public class BookmarkListService {
 
     public List<ParkingSpaceMapDto> getParkingSpaceList(String email, String sort) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         List<SpaceBookmark> spaceBookmarks;
 
-        if("earliest".equals(sort)) {
-            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
-        } else if ("latest".equals(sort)) {
+        if("latest".equals(sort)) {
             spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtDesc(user);
+        } else if ("earliest".equals(sort)) {
+            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
         } else {
-            spaceBookmarks = spaceBookmarkRepository.findByUser(user); // 에러 추가 예정
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
         return spaceBookmarks.stream()

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
@@ -6,6 +6,8 @@ import com.si9nal.parker.bookmark.dto.res.SpaceBookmarkResDto;
 import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
 import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
 import com.si9nal.parker.bookmark.repository.ViolationBookmarkRepository;
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
 import com.si9nal.parker.parkingspace.domain.ParkingSpace;
 import com.si9nal.parker.parkingspace.repository.ParkingSpaceRepository;
 import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
@@ -32,10 +34,10 @@ public class BookmarkService {
     public ViolationBookmarkResDto toggleViolationBookmark(String email, Long parkingViolationId) {
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_AUTHENTICATED));
 
         ParkingViolation parkingViolation = parkingViolationRepository.findById(parkingViolationId)
-                .orElseThrow(() -> new EntityNotFoundException("주정차 단속 구간 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PARKING_VIOLATION_NOT_FOUND));
 
         Optional<ViolationBookmark> existingBookmark = violationBookmarkRepository.findByUserAndParkingViolation(user, parkingViolation);
 
@@ -56,10 +58,10 @@ public class BookmarkService {
     public SpaceBookmarkResDto toggleSpaceBookmark(String email, Long parkingSpaceId) {
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         ParkingSpace parkingSpace = parkingSpaceRepository.findById(parkingSpaceId)
-                .orElseThrow(() -> new EntityNotFoundException("주차장 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PARKING_SPACE_NOT_FOUND));
 
         Optional<SpaceBookmark> existingBookmark = spaceBookmarkRepository.findByUserAndParkingSpace(user, parkingSpace);
 


### PR DESCRIPTION
# ✨ 구현한 내용
- 응답 구조 통일
- 애러 처리
- swagger 적용

📎 샘플 데이터 (선택)
<br><br>

# ✅ 테스트 내용
- 테스트 내용 설명

📎 테스트 결과 스크린샷 (선택)
1. 주차공간 즐겨찾기 추가 
![image](https://github.com/user-attachments/assets/769b9310-e6a0-4a44-8cf3-51d8487b6f13)
 
2. 주차공간 즐겨찾기 삭제
![image](https://github.com/user-attachments/assets/1c37ea36-02ed-4731-a432-e6e6196656a7)

(불법 주정차 구역도 동일한 결과 입니다.)

3. 즐겨찾기 한 주차공간 조회
- 최신순
![image](https://github.com/user-attachments/assets/6d9041c9-bc07-44f3-9802-d3632a0f1f99)

- 오래된순
![image](https://github.com/user-attachments/assets/f4fa74d0-a60f-415c-9279-0aba55242844)


4. 에러처리
![image](https://github.com/user-attachments/assets/1e40b78f-612c-4bb5-ad88-2ecb4835157e)



# 📌 중점 리뷰 사항
- 응답구조와 에러처리 중점적으로 확인 부탁드립니다.
- 더 필요한 에러처리가 있을지 확인 부탁드려요.
<br><br>


# 🪪 이슈번호 : [#45 ]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @bigtr3 @jiwonniy 
