### PR TITLE
[#47 Feat] 현재 위치 기반 단속 카메라 위치 조회

### DIFF
--- a/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/controller/BookmarkController.java
@@ -5,6 +5,10 @@ import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
 import com.si9nal.parker.bookmark.service.BookmarkService;
 import com.si9nal.parker.bookmark.service.BookmarkListService;
 import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -12,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+@Tag(name = "즐겨찾기 API", description = "즐겨찾기 추가, 삭제, 조회 API")
 @RestController
 @RequestMapping("/api/bookmark")
 @RequiredArgsConstructor
@@ -19,33 +24,38 @@ public class BookmarkController {
     private final BookmarkService bookmarkService;
     private final BookmarkListService bookmarkListService;
 
+    @Operation(summary = "불법주정차 단속 구역 즐겨찾기 추가 및 삭제", description = "데이터가 존재하면 삭제, 데이터가 존재하지 않으면 추가합니다.")
     @PostMapping("/parking-violation/{id}")
     public ResponseEntity<ViolationBookmarkResDto> toggleViolationBookmark(
-            
             @AuthenticationPrincipal String email,
+            @Parameter (description = "즐겨찾기를 추가/삭제 할 불법주정차 단속 구역 ID", example = "1")
             @PathVariable Long id
     ) {
-
             ViolationBookmarkResDto violationBookmarkResponse = bookmarkService.toggleViolationBookmark(email, id);
             return ResponseEntity.ok(violationBookmarkResponse);
-
     }
 
+    @Operation(summary = "주차공간 즐겨찾기 추가 및 삭제", description = "데이터가 존재하면 삭제, 데이터가 존재하지 않으면 추가합니다.")
     @PostMapping("/parking-space/{id}")
     public ResponseEntity<SpaceBookmarkResDto> toggleSpaceBookmark(
 
             @AuthenticationPrincipal String email,
+            @Parameter (description = "즐겨찾기를 추가/삭제 할 주차공간 ID", example = "1")
             @PathVariable Long id
     ) {
-
         SpaceBookmarkResDto spaceBookmarkResponse = bookmarkService.toggleSpaceBookmark(email, id);
         return ResponseEntity.ok(spaceBookmarkResponse);
-
     }
 
+    @Operation(summary = "즐겨찾기 한 주차공간 조회", description = "최신순, 오래된순 으로 조회할 수 있으며 요청 파라미터 없을 시 기본 최신순으로 조회")
     @GetMapping("/parking-space-list")
     public ResponseEntity<List<ParkingSpaceMapDto>> getParkingSpaceList (
             @AuthenticationPrincipal String email,
+            @Parameter(description = "정렬 방법", examples = {
+                    @ExampleObject(name = "최신순", value = "latest"),
+                    @ExampleObject(name = "오래된순", value = "earliest")
+                }
+            )
             @RequestParam(required = false, defaultValue = "latest") String sort
     ) {
         List<ParkingSpaceMapDto> parkingSpaceListResponse = bookmarkListService.getParkingSpaceList(email, sort);

--- a/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/repository/SpaceBookmarkRepository.java
@@ -15,7 +15,6 @@ public interface SpaceBookmarkRepository extends JpaRepository<SpaceBookmark, Lo
     boolean existsByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
 
     Optional<SpaceBookmark> findByUserAndParkingSpace(User user, ParkingSpace parkingSpace);
-    List<SpaceBookmark> findByUser(User user);
     List<SpaceBookmark> findByUserOrderByCreatedAtAsc(User user);
     List<SpaceBookmark> findByUserOrderByCreatedAtDesc(User user);
 }

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkListService.java
@@ -2,6 +2,8 @@ package com.si9nal.parker.bookmark.service;
 
 import com.si9nal.parker.bookmark.domain.SpaceBookmark;
 import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
 import com.si9nal.parker.parkingspace.dto.res.ParkingSpaceMapDto;
 import com.si9nal.parker.user.domain.User;
 import com.si9nal.parker.user.repository.UserRepository;
@@ -20,16 +22,16 @@ public class BookmarkListService {
 
     public List<ParkingSpaceMapDto> getParkingSpaceList(String email, String sort) {
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         List<SpaceBookmark> spaceBookmarks;
 
-        if("earliest".equals(sort)) {
-            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
-        } else if ("latest".equals(sort)) {
+        if("latest".equals(sort)) {
             spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtDesc(user);
+        } else if ("earliest".equals(sort)) {
+            spaceBookmarks = spaceBookmarkRepository.findByUserOrderByCreatedAtAsc(user);
         } else {
-            spaceBookmarks = spaceBookmarkRepository.findByUser(user); // 에러 추가 예정
+            throw new GeneralException(ErrorStatus._BAD_REQUEST);
         }
 
         return spaceBookmarks.stream()

--- a/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
+++ b/parker/src/main/java/com/si9nal/parker/bookmark/service/BookmarkService.java
@@ -6,6 +6,8 @@ import com.si9nal.parker.bookmark.dto.res.SpaceBookmarkResDto;
 import com.si9nal.parker.bookmark.dto.res.ViolationBookmarkResDto;
 import com.si9nal.parker.bookmark.repository.SpaceBookmarkRepository;
 import com.si9nal.parker.bookmark.repository.ViolationBookmarkRepository;
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
 import com.si9nal.parker.parkingspace.domain.ParkingSpace;
 import com.si9nal.parker.parkingspace.repository.ParkingSpaceRepository;
 import com.si9nal.parker.parkingviolation.domain.ParkingViolation;
@@ -32,10 +34,10 @@ public class BookmarkService {
     public ViolationBookmarkResDto toggleViolationBookmark(String email, Long parkingViolationId) {
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_AUTHENTICATED));
 
         ParkingViolation parkingViolation = parkingViolationRepository.findById(parkingViolationId)
-                .orElseThrow(() -> new EntityNotFoundException("주정차 단속 구간 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PARKING_VIOLATION_NOT_FOUND));
 
         Optional<ViolationBookmark> existingBookmark = violationBookmarkRepository.findByUserAndParkingViolation(user, parkingViolation);
 
@@ -56,10 +58,10 @@ public class BookmarkService {
     public SpaceBookmarkResDto toggleSpaceBookmark(String email, Long parkingSpaceId) {
 
         User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new EntityNotFoundException("사용자 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
         ParkingSpace parkingSpace = parkingSpaceRepository.findById(parkingSpaceId)
-                .orElseThrow(() -> new EntityNotFoundException("주차장 조회에 실패했습니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PARKING_SPACE_NOT_FOUND));
 
         Optional<SpaceBookmark> existingBookmark = spaceBookmarkRepository.findByUserAndParkingSpace(user, parkingSpace);
 

--- a/parker/src/main/java/com/si9nal/parker/camera/controller/CameraLocationController.java
+++ b/parker/src/main/java/com/si9nal/parker/camera/controller/CameraLocationController.java
@@ -24,7 +24,7 @@ public class CameraLocationController {
 
     private final CameraLocationService cameraLocationService;
 
-    @Operation(summary = "단속 카메라 위치 조회", description = "메인 지도에서 사용자의 위치 2km 안의 단속카메라의 위치를 불러옵니다.")
+    @Operation(summary = "단속 카메라 위치 조회", description = "메인 지도에서 사용자의 위치 500m 안의 단속카메라의 위치를 불러옵니다.")
     @GetMapping("/camera-location-map")
     public ResponseEntity<ApiResponse<List<CameraLocationResponse>>> getMapWithCameraLocation (
             @Parameter(description = "사용자의 위도", example = "37.5358", required = true)

--- a/parker/src/main/java/com/si9nal/parker/camera/controller/CameraLocationController.java
+++ b/parker/src/main/java/com/si9nal/parker/camera/controller/CameraLocationController.java
@@ -1,0 +1,42 @@
+package com.si9nal.parker.camera.controller;
+
+import com.si9nal.parker.camera.service.CameraLocationService;
+import com.si9nal.parker.global.common.apiPayload.ApiResponse;
+import com.si9nal.parker.global.common.apiPayload.code.status.SuccessStatus;
+import com.si9nal.parker.map.dto.response.CameraLocationResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "메인 지도 API", description = "메인 지도화면에서 주차장, 주정차금지구역 조회를 제공하는 API")
+@RestController
+@RequestMapping("/api/parker")
+@RequiredArgsConstructor
+public class CameraLocationController {
+
+    private final CameraLocationService cameraLocationService;
+
+    @Operation(summary = "단속 카메라 위치 조회", description = "메인 지도에서 사용자의 위치 2km 안의 단속카메라의 위치를 불러옵니다.")
+    @GetMapping("/camera-location-map")
+    public ResponseEntity<ApiResponse<List<CameraLocationResponse>>> getMapWithCameraLocation (
+            @Parameter(description = "사용자의 위도", example = "37.5358", required = true)
+            @RequestParam Double latitude,
+            @Parameter(description = "사용자의 경도", example = "126.8705", required = true)
+            @RequestParam Double longitude) {
+
+        List<CameraLocationResponse> nearbyCamera = cameraLocationService.findNearbyCameras(latitude, longitude);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(SuccessStatus._OK, nearbyCamera)
+        );
+
+    }
+}

--- a/parker/src/main/java/com/si9nal/parker/camera/service/CameraLocationService.java
+++ b/parker/src/main/java/com/si9nal/parker/camera/service/CameraLocationService.java
@@ -1,0 +1,55 @@
+package com.si9nal.parker.camera.service;
+
+import com.si9nal.parker.camera.repository.CameraLocationRepository;
+import com.si9nal.parker.global.common.apiPayload.code.status.ErrorStatus;
+import com.si9nal.parker.global.common.apiPayload.exception.GeneralException;
+import com.si9nal.parker.global.common.util.Direction;
+import com.si9nal.parker.global.common.util.GeometryUtil;
+import com.si9nal.parker.global.common.util.Location;
+import com.si9nal.parker.map.dto.response.CameraLocationResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CameraLocationService {
+
+    private final CameraLocationRepository cameraLocationRepository;
+
+    public List<CameraLocationResponse> findNearbyCameras (Double latitude, Double longitude) {
+
+        validateCoordinates(latitude, longitude);
+
+        Location northEast = GeometryUtil.calculate(latitude, longitude, 2.0, Direction.NORTHEAST.getBearing());
+        Location southWest = GeometryUtil.calculate(latitude, longitude, 2.0, Direction.SOUTHWEST.getBearing());
+
+        Location camera_northEast = GeometryUtil.calculate(latitude, longitude, 0.5, Direction.NORTHEAST.getBearing());
+        Location camera_southWest = GeometryUtil.calculate(latitude, longitude, 0.5, Direction.SOUTHWEST.getBearing());
+
+        List<CameraLocationResponse> cameraLocations = cameraLocationRepository.findCameraLocationsWithinBounds(
+                        camera_southWest.getLatitude(), camera_northEast.getLatitude(),
+                        camera_southWest.getLongitude(), camera_northEast.getLongitude())
+                .stream()
+                .map(CameraLocationResponse::fromEntity)
+                .collect(Collectors.toList());
+
+        if(cameraLocations.isEmpty()) {
+            throw new GeneralException(ErrorStatus.CAMERA_LOCATION_NOT_FOUND);
+        }
+
+        return cameraLocations;
+    }
+
+    private void validateCoordinates(Double latitude, Double longitude) {
+        if (latitude == null || latitude < -90 || latitude > 90) {
+            throw new GeneralException(ErrorStatus.CAMERA_LOCATION_INVALID_LATITUDE);
+        }
+        if (longitude == null || longitude < -180 || longitude > 180) {
+            throw new GeneralException(ErrorStatus.CAMERA_LOCATION_INVALID_LONGITUDE);
+        }
+    }
+
+}

--- a/parker/src/main/java/com/si9nal/parker/camera/service/CameraLocationService.java
+++ b/parker/src/main/java/com/si9nal/parker/camera/service/CameraLocationService.java
@@ -23,9 +23,6 @@ public class CameraLocationService {
 
         validateCoordinates(latitude, longitude);
 
-        Location northEast = GeometryUtil.calculate(latitude, longitude, 2.0, Direction.NORTHEAST.getBearing());
-        Location southWest = GeometryUtil.calculate(latitude, longitude, 2.0, Direction.SOUTHWEST.getBearing());
-
         Location camera_northEast = GeometryUtil.calculate(latitude, longitude, 0.5, Direction.NORTHEAST.getBearing());
         Location camera_southWest = GeometryUtil.calculate(latitude, longitude, 0.5, Direction.SOUTHWEST.getBearing());
 

--- a/parker/src/main/java/com/si9nal/parker/global/common/apiPayload/code/status/ErrorStatus.java
+++ b/parker/src/main/java/com/si9nal/parker/global/common/apiPayload/code/status/ErrorStatus.java
@@ -38,7 +38,12 @@ public enum ErrorStatus implements BaseErrorCode {
     REPORT_INVALID_STATUS(HttpStatus.BAD_REQUEST, "REPORT4004", "유효하지 않은 신고 상태입니다."),
 
     // 불법주정차 관련 에러
-    PARKING_VIOLATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VIOLATION4001", "해당 위치의 불법 주정차 정보가 없습니다.");
+    PARKING_VIOLATION_NOT_FOUND(HttpStatus.NOT_FOUND, "VIOLATION4001", "해당 위치의 불법 주정차 정보가 없습니다."),
+
+    //단속 카메라 관련 에러
+    CAMERA_LOCATION_INVALID_LATITUDE(HttpStatus.BAD_REQUEST, "CAMERA4001", "유효하지 않은 위도 값입니다. -90에서 90 사이의 값이어야 합니다."),
+    CAMERA_LOCATION_INVALID_LONGITUDE(HttpStatus.BAD_REQUEST, "CAMERA4002", "유효하지 않은 경도 값입니다. -180에서 180 사이의 값이어야 합니다."),
+    CAMERA_LOCATION_NOT_FOUND(HttpStatus.NOT_FOUND, "CAMERA4003", "주변에 단속카메라를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;


### PR DESCRIPTION
# ✨ 구현한 내용
- 사용자 현재 위치 기반으로 단속 카메라 위치 조회
- #45번 브렌치에서 새로운 브렌치 #47번을 생성해 작업했습니다.
<br><br>

### 1. 사용자의 현재 위치 기반으로 500m 이내의 단속 카메라 위치 조회
- 사용한 데이터 : camera_location_filtered1.csv
- 제공 받은 위도와 경도를 사용하여 geimetryutil 로 500m 이내에 해당하는 공간 범위를 계산
- 계산된 범위 내에서 단속 카메라 위치 정보 조회

📎 샘플 데이터 (선택)
<br><br>


# ✅ 테스트 내용
- 테스트 내용 설명

📎 테스트 결과 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/acba1518-a82b-4285-9287-2c967a9eeaa9)
![image](https://github.com/user-attachments/assets/0de72b7a-eb3c-4dcf-ba93-2609680861a0)
![image](https://github.com/user-attachments/assets/32eae4d1-3d85-4d31-8260-c1fbc742a2b8)

<br><br>


# 📌 중점 리뷰 사항
- 기존 구현되어 있는 다른 부분들과 통일된 방법으로 구현했습니다.
- swagger 적용할 때 tag 를 기존에 존재하는 메인 지도 API 에 포함되도록 했는데 따로 빼는게 좋을지 확인 부탁드립니다.
<br><br>


# 🪪 이슈번호 : [#47 ]
<br><br>


# 🙋‍♂️ 리뷰어
@seun0123 @bigtr3 @jiwonniy 
